### PR TITLE
add documentation to module path aliases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,10 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 5. Make sure your code lints.
 6. Issue that pull request!
 
+## We Use Module Path Aliases
+
+Look at [Next.js Documention](https://nextjs.org/docs/advanced-features/module-path-aliases) and the `jsconfig.js` file for further instuctions on absolute imports and module path aliases. Please keep this in mind if you need to add imports to make changes.
+
 ## Any contributions you make will be under the MIT Software License
 
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,30 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 
 Look at [Next.js Documention](https://nextjs.org/docs/advanced-features/module-path-aliases) and the `jsconfig.js` file for further instuctions on absolute imports and module path aliases. Please keep this in mind if you need to add imports to make changes.
 
+To add a new alias go to `jsconfig.json`
+```js
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["components/*"],
+      "@/models/*": ["models/*"],
+      "@/pages/*": ["pages/*"],
+      // ...etc
+      
+      // for example following the format
+      // "@/<folder>/*": ["<path to folder>/*"]
+      // add
+      "@/customButtons/*": ["components/customButtons/*"]
+    }
+  }
+}
+```
+then import
+```js
+import myCustomButton from '@/customButtons/myCustomButton'
+```
+
 ## Any contributions you make will be under the MIT Software License
 
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute fill out the below fields to provide more context on the incoming changes
-->

add module path aliases to docs

- [x] I have followed the [Contributing Guidelines](https://github.com/Hurly77/Devocidy).

- [N/A] I added/replaced tests following these changes.

Steps:

1. add a section to docs about module path aliases

closes #47 